### PR TITLE
Enhance TrailsRelaySapientSignerTest with additional attested execution info

### DIFF
--- a/test/TrailsRelaySapientSigner.t.sol
+++ b/test/TrailsRelaySapientSigner.t.sol
@@ -192,8 +192,14 @@ contract TrailsRelaySapientSignerTest is Test {
         Payload.Decoded memory payload = _createPayload(calls, 3, false);
 
         // 4. Prepare attested execution infos for the relay call only
-        TrailsExecutionInfo[] memory attestedExecutionInfos = new TrailsExecutionInfo[](1);
+        TrailsExecutionInfo[] memory attestedExecutionInfos = new TrailsExecutionInfo[](2);
         attestedExecutionInfos[0] = TrailsExecutionInfo({
+            originToken: address(mockToken),
+            amount: approvalAmount,
+            originChainId: block.chainid,
+            destinationChainId: block.chainid
+        });
+        attestedExecutionInfos[1] = TrailsExecutionInfo({
             originToken: address(mockToken),
             amount: transferAmount,
             originChainId: block.chainid,


### PR DESCRIPTION
- Updated the test to include a second attested execution info entry, improving coverage for different execution scenarios.
- Ensured that both entries correctly reference the mock token and respective amounts, enhancing the accuracy of the test cases.
