### PR TITLE
(pausable option A) Add PayloadSwitchSapient

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ onlyFallback: false
 
 ### Payload Switch Sapient
 
-[PayloadSwitchSapient.sol](src/modules/PayloadSwitchSapient.sol) is an [`ISapient`](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol) helper with a `disabled` kill switch (defaults off): the owner can call `setDisabled(true)` so `recoverSapientSignature` reverts and the wallet drops that branch; while not disabled, it returns the same digest leaf as any-address subdigest checks (`hashFor` with the zero address, then the `"Sequence any address subdigest:\n"` prefix), for use with the standard sapient path rather than `ISapientCompact`.
+[PayloadSwitchSapient.sol](src/modules/PayloadSwitchSapient.sol) is an [`ISapient`](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol) helper with a pause switch (defaults off): the owner or an approved operator can call `pause()` so `recoverSapientSignature` reverts and the wallet drops that branch; only the owner can `unpause()`. While not paused, it returns the same digest leaf as any-address subdigest checks (`hashFor` with the zero address, then the `"Sequence any address subdigest:\n"` prefix), for use with the standard sapient path rather than `ISapientCompact`.
 
 ## Glossary
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Hydrator logic supports the following replacements:
 
 #### MalleableSapient
 
-[MalleableSapient.sol](src/modules/MalleableSapient.sol) implements the [ISapient interface](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol) used by Sequence Wallets to support singleton counter factual configurations derived at runtime.
+[MalleableSapient.sol](src/modules/MalleableSapient.sol) implements the [ISapient interface](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol) used by Sequence Wallets to support singleton counter factual configurations derived at runtime. It is gated by an external pause source and reverts while that source reports `paused() == true`.
 
 Sequence Wallets support preauthorization of entire payload digests. This does not support all Trails providers. Some information (e.g. commit / reveal bridges) do not allow the entire payload to be known when constructing the Intent supported Payloads.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ onlyFallback: false
 
 [Sweep](src/modules/Sweep.sol) allows the entire balance (ERC20, address(this).balance) to be sent to another address.
 
+### Payload Switch Sapient
+
+[PayloadSwitchSapient.sol](src/modules/PayloadSwitchSapient.sol) is an [`ISapient`](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol) helper with a `disabled` kill switch (defaults off): the owner can call `setDisabled(true)` so `recoverSapientSignature` reverts and the wallet drops that branch; while not disabled, it returns the same digest leaf as any-address subdigest checks (`hashFor` with the zero address, then the `"Sequence any address subdigest:\n"` prefix), for use with the standard sapient path rather than `ISapientCompact`.
+
 ## Glossary
 
 | Term           | Definition                                                     |
@@ -102,7 +106,7 @@ Any funds accumulated in the `TrailsUtils` context, via a `call` should be swept
 
 The Trails contracts are flexible in what they allow a configuration to represent. Misuse can cause an Intent to be exploitable.
 
-`RequireUtils`, `HydrateProxy` and `MalleableSapient` are tools to help create functionally complete and secure Intent configurations. The actual creation of the configuration must be done with care and is out of scope of this repository.
+`RequireUtils`, `HydrateProxy`, `MalleableSapient` and `PayloadSwitchSapient` are tools to help create functionally complete and secure Intent configurations. The actual creation of the configuration must be done with care and is out of scope of this repository.
 
 ### Token Handling
 

--- a/itest/SequenceV3Integration.t.sol
+++ b/itest/SequenceV3Integration.t.sol
@@ -7,6 +7,7 @@ import {TrailsUtils} from "src/TrailsUtils.sol";
 import {Allowlist} from "src/autoRecovery/Allowlist.sol";
 import {TimedRefundSapient} from "src/autoRecovery/TimedRefundSapient.sol";
 import {HydrateProxy} from "src/modules/HydrateProxy.sol";
+import {PayloadSwitchSapient} from "src/modules/PayloadSwitchSapient.sol";
 
 import {PackedPayload} from "trails-test/helpers/PackedPayload.sol";
 import {MockERC20, RecordingReceiver} from "trails-test/helpers/Mocks.sol";
@@ -279,7 +280,9 @@ contract SequenceV3IntegrationTest is Test {
   }
 
   function testFuzz_integration_sapientSigner_allowsMalleableCalldata(bytes32 seed) external {
-    TrailsUtils trailsUtils = new TrailsUtils();
+    address[] memory initialOperators = new address[](0);
+    PayloadSwitchSapient pauseSource = new PayloadSwitchSapient(address(this), initialOperators);
+    TrailsUtils trailsUtils = new TrailsUtils(address(pauseSource));
 
     SeqFactory factory = new SeqFactory();
     SeqStage1Module stage1 = new SeqStage1Module(address(factory), address(0));
@@ -340,7 +343,9 @@ contract SequenceV3IntegrationTest is Test {
   }
 
   function test_integration_walletDelegatecallsHydrateProxy_andHydrates() external {
-    TrailsUtils trailsUtils = new TrailsUtils();
+    address[] memory initialOperators = new address[](0);
+    PayloadSwitchSapient pauseSource = new PayloadSwitchSapient(address(this), initialOperators);
+    TrailsUtils trailsUtils = new TrailsUtils(address(pauseSource));
 
     SeqFactory factory = new SeqFactory();
     SeqStage1Module stage1 = new SeqStage1Module(address(factory), address(0));

--- a/src/TrailsUtils.sol
+++ b/src/TrailsUtils.sol
@@ -11,4 +11,6 @@ import {RequireUtils} from "src/modules/RequireUtils.sol";
 /// - {MalleableSapient} for malleable commitments
 /// - {HydrateProxy} for hydrate + execute flows
 /// - {RequireUtils} for precondition checks
-contract TrailsUtils is MalleableSapient, HydrateProxy, RequireUtils {}
+contract TrailsUtils is MalleableSapient, HydrateProxy, RequireUtils {
+  constructor(address pauseSource) MalleableSapient(pauseSource) {}
+}

--- a/src/modules/MalleableSapient.sol
+++ b/src/modules/MalleableSapient.sol
@@ -25,11 +25,23 @@ import {LibOptim} from "wallet-contracts-v3/utils/LibOptim.sol";
 /// - `cindex2` (uint16): byte offset into `payload.calls[tindex2].data`
 /// - This is *not* an ECDSA signature; it's a compact description of the committed sections.
 contract MalleableSapient is ISapient {
+  error InvalidPauseSource(address pauseSource);
+  error EnforcedPause();
   error NonTransactionPayload();
 
   error InvalidRepeatSection(uint256 _tindex, uint256 _cindex, uint256 _size, uint256 _tindex2, uint256 _cindex2);
 
   using LibBytes for bytes;
+
+  address public immutable pauseSource;
+
+  constructor(address pauseSource_) {
+    if (pauseSource_ == address(0)) {
+      revert InvalidPauseSource(address(0));
+    }
+
+    pauseSource = pauseSource_;
+  }
 
   /// @inheritdoc ISapient
   /// @dev Computes the `imageHash` for a transaction payload with a malleable `data` commitment.
@@ -38,6 +50,10 @@ contract MalleableSapient is ISapient {
     view
     returns (bytes32 imageHash)
   {
+    if (IPauseSource(pauseSource).paused()) {
+      revert EnforcedPause();
+    }
+
     if (payload.kind != Payload.KIND_TRANSACTIONS) {
       revert NonTransactionPayload();
     }
@@ -116,4 +132,8 @@ contract MalleableSapient is ISapient {
   function _staticSection(uint256 _tindex, uint256 _cindex, bytes calldata _data) internal pure returns (bytes32) {
     return keccak256(abi.encode("static-section", _tindex, _cindex, _data));
   }
+}
+
+interface IPauseSource {
+  function paused() external view returns (bool);
 }

--- a/src/modules/PayloadSwitchSapient.sol
+++ b/src/modules/PayloadSwitchSapient.sol
@@ -1,44 +1,88 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.27;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ISapient} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
 import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
 
 using Payload for Payload.Decoded;
 
 /// @title PayloadSwitchSapient
-/// @notice An `ISapient` that wraps subdigest authorisation under a kill switch.
-contract PayloadSwitchSapient is ISapient {
-  /// @notice The caller is not the owner.
-  error NotOwner();
+/// @notice An `ISapient` that wraps subdigest authorisation under a pause switch.
+contract PayloadSwitchSapient is ISapient, Ownable {
+  /// @notice The zero address was provided where an operator address is required.
+  error ZeroAddress();
+  /// @notice The caller is neither the owner nor a pause operator.
+  error UnauthorizedPauser(address account);
+  /// @notice Subdigest authorisation is paused.
+  error EnforcedPause();
+  /// @notice Subdigest authorisation is not paused.
+  error ExpectedPause();
 
-  /// @notice Subdigest authorisation is disabled.
-  error Disabled();
+  /// @notice Returns whether `account` is allowed to pause.
+  mapping(address => bool) public isOperator;
+  /// @notice Returns whether subdigest authorisation is paused.
+  bool public paused;
 
-  /// @notice The owner of the contract.
-  address public owner;
+  /// @notice Emitted when `account` pauses the contract.
+  event Paused(address indexed account);
+  /// @notice Emitted when `account` unpauses the contract.
+  event Unpaused(address indexed account);
+  /// @notice Emitted when an operator permission is updated.
+  event OperatorSet(address indexed operator, bool allowed);
 
-  /// @notice Whether subdigest authorisation is disabled.
-  bool public disabled;
+  constructor(address owner_, address[] memory initialOperators) Ownable(owner_) {
+    for (uint256 i; i < initialOperators.length; i++) {
+      address operator = initialOperators[i];
+      if (operator == address(0)) {
+        revert ZeroAddress();
+      }
 
-  constructor(address owner_) {
-    owner = owner_;
+      isOperator[operator] = true;
+    }
   }
 
-  /// @notice Sets the disabled state.
-  /// @param disabled_ The new disabled state.
-  function setDisabled(bool disabled_) external {
-    if (msg.sender != owner) {
-      revert NotOwner();
+  /// @notice Pauses subdigest authorisation.
+  /// @dev Callable by the owner or an approved operator.
+  function pause() external {
+    if (paused) {
+      revert EnforcedPause();
     }
-    disabled = disabled_;
+
+    if (msg.sender != owner() && !isOperator[msg.sender]) {
+      revert UnauthorizedPauser(msg.sender);
+    }
+
+    paused = true;
+    emit Paused(msg.sender);
+  }
+
+  /// @notice Unpauses subdigest authorisation.
+  /// @dev Callable only by the owner.
+  function unpause() external onlyOwner {
+    if (!paused) {
+      revert ExpectedPause();
+    }
+
+    paused = false;
+    emit Unpaused(msg.sender);
+  }
+
+  /// @notice Updates whether `operator` is allowed to pause.
+  function setOperator(address operator, bool allowed) external onlyOwner {
+    if (operator == address(0)) {
+      revert ZeroAddress();
+    }
+
+    isOperator[operator] = allowed;
+    emit OperatorSet(operator, allowed);
   }
 
   /// @inheritdoc ISapient
   /// @notice Returns the subdigest authorisation signature.
   function recoverSapientSignature(Payload.Decoded calldata payload, bytes calldata) external view returns (bytes32) {
-    if (disabled) {
-      revert Disabled();
+    if (paused) {
+      revert EnforcedPause();
     }
     return _leafForPayload(payload);
   }

--- a/src/modules/PayloadSwitchSapient.sol
+++ b/src/modules/PayloadSwitchSapient.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.27;
 
-import {ISapientCompact} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
+import {ISapient} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
+import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
+
+using Payload for Payload.Decoded;
 
 /// @title PayloadSwitchSapient
-/// @notice An `ISapientCompact` that wraps subdigest authorisation under a kill switch.
-contract PayloadSwitchSapient is ISapientCompact {
+/// @notice An `ISapient` that wraps subdigest authorisation under a kill switch.
+contract PayloadSwitchSapient is ISapient {
   /// @notice The caller is not the owner.
   error NotOwner();
 
@@ -31,12 +34,19 @@ contract PayloadSwitchSapient is ISapientCompact {
     enabled = enabled_;
   }
 
-  /// @inheritdoc ISapientCompact
+  /// @inheritdoc ISapient
   /// @notice Returns the subdigest authorisation signature.
-  function recoverSapientSignatureCompact(bytes32 digest, bytes calldata) external view returns (bytes32) {
+  function recoverSapientSignature(Payload.Decoded calldata payload, bytes calldata) external view returns (bytes32) {
     if (!enabled) {
       revert Disabled();
     }
-    return digest;
+    return _leafForPayload(payload);
+  }
+
+  /// @notice Returns the leaf for a payload.
+  /// @dev This copies the FLAG_SIGNATURE_ANY_ADDRESS_SUBDIGEST encoding used by the wallet.
+  function _leafForPayload(Payload.Decoded calldata _payload) internal view returns (bytes32) {
+    bytes32 anyAddressOpHash = _payload.hashFor(address(0));
+    return keccak256(abi.encodePacked("Sequence any address subdigest:\n", anyAddressOpHash));
   }
 }

--- a/src/modules/PayloadSwitchSapient.sol
+++ b/src/modules/PayloadSwitchSapient.sol
@@ -12,6 +12,8 @@ using Payload for Payload.Decoded;
 contract PayloadSwitchSapient is ISapient, Ownable {
   /// @notice The zero address was provided where an operator address is required.
   error ZeroAddress();
+  /// @notice Ownership renunciation is disabled to preserve an account that can unpause.
+  error OwnershipRenunciationDisabled();
   /// @notice The caller is neither the owner nor a pause operator.
   error UnauthorizedPauser(address account);
   /// @notice Subdigest authorisation is paused.
@@ -76,6 +78,11 @@ contract PayloadSwitchSapient is ISapient, Ownable {
 
     isOperator[operator] = allowed;
     emit OperatorSet(operator, allowed);
+  }
+
+  /// @notice Disables ownership renunciation so the pause switch cannot become permanently stuck.
+  function renounceOwnership() public view override onlyOwner {
+    revert OwnershipRenunciationDisabled();
   }
 
   /// @inheritdoc ISapient

--- a/src/modules/PayloadSwitchSapient.sol
+++ b/src/modules/PayloadSwitchSapient.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {ISapientCompact} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
+
+/// @title PayloadSwitchSapient
+/// @notice An `ISapientCompact` that wraps subdigest authorisation under a kill switch.
+contract PayloadSwitchSapient is ISapientCompact {
+  /// @notice The caller is not the owner.
+  error NotOwner();
+
+  /// @notice Subdigest authorisation is disabled.
+  error Disabled();
+
+  /// @notice The owner of the contract.
+  address public owner;
+
+  /// @notice Whether subdigest authorisation is enabled.
+  bool public enabled;
+
+  constructor(address owner_) {
+    owner = owner_;
+  }
+
+  /// @notice Sets the enabled state.
+  /// @param enabled_ The new enabled state.
+  function setEnabled(bool enabled_) external {
+    if (msg.sender != owner) {
+      revert NotOwner();
+    }
+    enabled = enabled_;
+  }
+
+  /// @inheritdoc ISapientCompact
+  /// @notice Returns the subdigest authorisation signature.
+  function recoverSapientSignatureCompact(bytes32 digest, bytes calldata) external view returns (bytes32) {
+    if (!enabled) {
+      revert Disabled();
+    }
+    return digest;
+  }
+}

--- a/src/modules/PayloadSwitchSapient.sol
+++ b/src/modules/PayloadSwitchSapient.sol
@@ -18,26 +18,26 @@ contract PayloadSwitchSapient is ISapient {
   /// @notice The owner of the contract.
   address public owner;
 
-  /// @notice Whether subdigest authorisation is enabled.
-  bool public enabled;
+  /// @notice Whether subdigest authorisation is disabled.
+  bool public disabled;
 
   constructor(address owner_) {
     owner = owner_;
   }
 
-  /// @notice Sets the enabled state.
-  /// @param enabled_ The new enabled state.
-  function setEnabled(bool enabled_) external {
+  /// @notice Sets the disabled state.
+  /// @param disabled_ The new disabled state.
+  function setDisabled(bool disabled_) external {
     if (msg.sender != owner) {
       revert NotOwner();
     }
-    enabled = enabled_;
+    disabled = disabled_;
   }
 
   /// @inheritdoc ISapient
   /// @notice Returns the subdigest authorisation signature.
   function recoverSapientSignature(Payload.Decoded calldata payload, bytes calldata) external view returns (bytes32) {
-    if (!enabled) {
+    if (disabled) {
       revert Disabled();
     }
     return _leafForPayload(payload);

--- a/test/MalleableSapient.t.sol
+++ b/test/MalleableSapient.t.sol
@@ -4,10 +4,20 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 
 import {MalleableSapient} from "src/modules/MalleableSapient.sol";
+import {PayloadSwitchSapient} from "src/modules/PayloadSwitchSapient.sol";
 import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
 import {LibOptim} from "wallet-contracts-v3/utils/LibOptim.sol";
 
 contract MalleableSapientTest is Test {
+  function _newPauseSource() private returns (PayloadSwitchSapient pauseSource) {
+    address[] memory initialOperators = new address[](0);
+    pauseSource = new PayloadSwitchSapient(makeAddr("owner"), initialOperators);
+  }
+
+  function _newSapient() private returns (MalleableSapient) {
+    return new MalleableSapient(address(_newPauseSource()));
+  }
+
   function _randomBytes(uint256 len, bytes32 seed) private pure returns (bytes memory data) {
     data = new bytes(len);
 
@@ -88,7 +98,7 @@ contract MalleableSapientTest is Test {
   function testFuzz_recoverSapientSignature_reverts_nonTransactions(uint8 kind) external {
     vm.assume(kind != Payload.KIND_TRANSACTIONS);
 
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     Payload.Decoded memory payload;
     payload.kind = kind;
@@ -124,7 +134,7 @@ contract MalleableSapientTest is Test {
       });
     }
 
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     bytes32 got = sapient.recoverSapientSignature(payload, "");
     bytes32 expected = _expectedImageHash(payload, "");
@@ -216,7 +226,7 @@ contract MalleableSapientTest is Test {
       }
     }
 
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     bytes32 got = sapient.recoverSapientSignature(payload, signature);
     bytes32 expected = _expectedImageHash(payload, signature);
@@ -299,7 +309,7 @@ contract MalleableSapientTest is Test {
     // At least one of the repeat sections must be invalid
     vm.assume(invalidParts.size != 0);
 
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     vm.expectRevert(
       abi.encodeWithSelector(
@@ -315,7 +325,7 @@ contract MalleableSapientTest is Test {
   }
 
   function test_recoverSapientSignature_chainId_included() external {
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     Payload.Decoded memory payload;
     payload.kind = Payload.KIND_TRANSACTIONS;
@@ -340,7 +350,7 @@ contract MalleableSapientTest is Test {
   }
 
   function test_recoverSapientSignature_noChainId_zeroUsed() external {
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     Payload.Decoded memory payload;
     payload.kind = Payload.KIND_TRANSACTIONS;
@@ -415,7 +425,7 @@ contract MalleableSapientTest is Test {
       payloadNoChainId.calls[i] = call;
     }
 
-    MalleableSapient sapient = new MalleableSapient();
+    MalleableSapient sapient = _newSapient();
 
     bytes32 hashWithChainId = sapient.recoverSapientSignature(payloadWithChainId, "");
     bytes32 hashNoChainId = sapient.recoverSapientSignature(payloadNoChainId, "");
@@ -426,5 +436,27 @@ contract MalleableSapientTest is Test {
     // Verify they match expected values
     assertEq(hashWithChainId, _expectedImageHash(payloadWithChainId, ""));
     assertEq(hashNoChainId, _expectedImageHash(payloadNoChainId, ""));
+  }
+
+  function test_constructor_revertsOnZeroPauseSource() external {
+    vm.expectRevert(abi.encodeWithSelector(MalleableSapient.InvalidPauseSource.selector, address(0)));
+    new MalleableSapient(address(0));
+  }
+
+  function test_recoverSapientSignature_revertsWhenPauseSourcePaused() external {
+    address owner = makeAddr("owner");
+    address[] memory initialOperators = new address[](0);
+    PayloadSwitchSapient pauseSource = new PayloadSwitchSapient(owner, initialOperators);
+    MalleableSapient sapient = new MalleableSapient(address(pauseSource));
+
+    Payload.Decoded memory payload;
+    payload.kind = Payload.KIND_TRANSACTIONS;
+    payload.calls = new Payload.Call[](0);
+
+    vm.prank(owner);
+    pauseSource.pause();
+
+    vm.expectRevert(MalleableSapient.EnforcedPause.selector);
+    sapient.recoverSapientSignature(payload, "");
   }
 }

--- a/test/PayloadSwitchSapient.t.sol
+++ b/test/PayloadSwitchSapient.t.sol
@@ -155,6 +155,14 @@ contract PayloadSwitchSapientTest is Test {
     sapient.setOperator(address(0), true);
   }
 
+  function test_renounceOwnership_reverts() external {
+    vm.prank(owner);
+    vm.expectRevert(PayloadSwitchSapient.OwnershipRenunciationDisabled.selector);
+    sapient.renounceOwnership();
+
+    assertEq(sapient.owner(), owner);
+  }
+
   function test_constructor_revertsOnZeroOperator() external {
     address[] memory initialOperators = new address[](1);
     initialOperators[0] = address(0);

--- a/test/PayloadSwitchSapient.t.sol
+++ b/test/PayloadSwitchSapient.t.sol
@@ -25,54 +25,57 @@ contract PayloadSwitchSapientTest is Test {
     assertEq(sapient.owner(), owner);
   }
 
-  function test_enabled_defaultsFalse() external {
-    assertFalse(sapient.enabled());
+  function test_disabled_defaultsFalse() external {
+    assertFalse(sapient.disabled());
   }
 
-  function test_recoverSapientSignature_revertsWhenDisabled() external {
-    Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xabc)));
-    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
-    sapient.recoverSapientSignature(payload, hex"");
-  }
-
-  function test_setEnabled_owner_allowsRecoverToReturnLeafForPayload() external {
+  function test_recoverSapientSignature_returnsLeafWhenNotDisabled() external {
     Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xdeadbeef)));
-    vm.prank(owner);
-    sapient.setEnabled(true);
-    assertTrue(sapient.enabled());
+    assertFalse(sapient.disabled());
     bytes32 h = sapient.recoverSapientSignature(payload, hex"01");
     assertEq(h, _expectedLeaf(payload));
   }
 
-  function test_setEnabled_owner_canDisableAgain() external {
+  function test_recoverSapientSignature_revertsWhenDisabled() external {
+    Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xabc)));
+    vm.prank(owner);
+    sapient.setDisabled(true);
+    assertTrue(sapient.disabled());
+    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.recoverSapientSignature(payload, hex"");
+  }
+
+  function test_setDisabled_owner_canClearAndRecoverAgain() external {
     Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(1)));
     vm.startPrank(owner);
-    sapient.setEnabled(true);
-    sapient.setEnabled(false);
-    vm.stopPrank();
-    assertFalse(sapient.enabled());
+    sapient.setDisabled(true);
     vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
     sapient.recoverSapientSignature(payload, "");
+    sapient.setDisabled(false);
+    vm.stopPrank();
+    assertFalse(sapient.disabled());
+    bytes32 h = sapient.recoverSapientSignature(payload, hex"");
+    assertEq(h, _expectedLeaf(payload));
   }
 
-  function test_setEnabled_nonOwner_reverts() external {
+  function test_setDisabled_nonOwner_reverts() external {
     vm.prank(makeAddr("notOwner"));
     vm.expectRevert(PayloadSwitchSapient.NotOwner.selector);
-    sapient.setEnabled(true);
+    sapient.setDisabled(true);
   }
 
-  function testFuzz_recoverSapientSignature_whenEnabled_returnsLeafForPayload(bytes32 digest, bytes memory data)
+  function testFuzz_recoverSapientSignature_whenNotDisabled_returnsLeafForPayload(bytes32 digest, bytes memory data)
     external
   {
     Payload.Decoded memory payload = Payload.fromDigest(digest);
-    vm.prank(owner);
-    sapient.setEnabled(true);
     bytes32 h = sapient.recoverSapientSignature(payload, data);
     assertEq(h, _expectedLeaf(payload));
   }
 
   function testFuzz_recoverSapientSignature_whenDisabled_reverts(bytes32 digest, bytes memory data) external {
     Payload.Decoded memory payload = Payload.fromDigest(digest);
+    vm.prank(owner);
+    sapient.setDisabled(true);
     vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
     sapient.recoverSapientSignature(payload, data);
   }

--- a/test/PayloadSwitchSapient.t.sol
+++ b/test/PayloadSwitchSapient.t.sol
@@ -2,13 +2,20 @@
 pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
 import {PayloadSwitchSapient} from "src/modules/PayloadSwitchSapient.sol";
 
 contract PayloadSwitchSapientTest is Test {
   address internal owner;
+  address internal operator;
+  address internal secondOperator;
   PayloadSwitchSapient internal sapient;
+
+  event Paused(address indexed account);
+  event Unpaused(address indexed account);
+  event OperatorSet(address indexed operator, bool allowed);
 
   function _expectedLeaf(Payload.Decoded memory payload) internal view returns (bytes32) {
     bytes32 anyAddressOpHash = Payload.hashFor(payload, address(0));
@@ -17,54 +24,146 @@ contract PayloadSwitchSapientTest is Test {
 
   function setUp() external {
     owner = makeAddr("owner");
-    vm.prank(owner);
-    sapient = new PayloadSwitchSapient(owner);
+    operator = makeAddr("operator");
+    secondOperator = makeAddr("secondOperator");
+
+    address[] memory initialOperators = new address[](1);
+    initialOperators[0] = operator;
+    sapient = new PayloadSwitchSapient(owner, initialOperators);
   }
 
   function test_constructor_setsOwner() external {
     assertEq(sapient.owner(), owner);
   }
 
-  function test_disabled_defaultsFalse() external {
-    assertFalse(sapient.disabled());
+  function test_constructor_setsOperators() external {
+    assertTrue(sapient.isOperator(operator));
+    assertFalse(sapient.isOperator(secondOperator));
   }
 
-  function test_recoverSapientSignature_returnsLeafWhenNotDisabled() external {
+  function test_paused_defaultsFalse() external {
+    assertFalse(sapient.paused());
+  }
+
+  function test_recoverSapientSignature_returnsLeafWhenNotPaused() external {
     Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xdeadbeef)));
-    assertFalse(sapient.disabled());
+    assertFalse(sapient.paused());
     bytes32 h = sapient.recoverSapientSignature(payload, hex"01");
     assertEq(h, _expectedLeaf(payload));
   }
 
-  function test_recoverSapientSignature_revertsWhenDisabled() external {
+  function test_recoverSapientSignature_revertsWhenPaused() external {
     Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xabc)));
     vm.prank(owner);
-    sapient.setDisabled(true);
-    assertTrue(sapient.disabled());
-    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.pause();
+    assertTrue(sapient.paused());
+    vm.expectRevert(PayloadSwitchSapient.EnforcedPause.selector);
     sapient.recoverSapientSignature(payload, hex"");
   }
 
-  function test_setDisabled_owner_canClearAndRecoverAgain() external {
+  function test_pause_ownerCanPauseAndUnpause() external {
     Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(1)));
-    vm.startPrank(owner);
-    sapient.setDisabled(true);
-    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, false);
+    emit Paused(owner);
+    sapient.pause();
+
+    vm.expectRevert(PayloadSwitchSapient.EnforcedPause.selector);
     sapient.recoverSapientSignature(payload, "");
-    sapient.setDisabled(false);
-    vm.stopPrank();
-    assertFalse(sapient.disabled());
+
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, false);
+    emit Unpaused(owner);
+    sapient.unpause();
+
+    assertFalse(sapient.paused());
     bytes32 h = sapient.recoverSapientSignature(payload, hex"");
     assertEq(h, _expectedLeaf(payload));
   }
 
-  function test_setDisabled_nonOwner_reverts() external {
-    vm.prank(makeAddr("notOwner"));
-    vm.expectRevert(PayloadSwitchSapient.NotOwner.selector);
-    sapient.setDisabled(true);
+  function test_pause_operatorCanPauseButCannotUnpause() external {
+    vm.prank(operator);
+    vm.expectEmit(true, false, false, false);
+    emit Paused(operator);
+    sapient.pause();
+
+    assertTrue(sapient.paused());
+
+    vm.prank(operator);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, operator));
+    sapient.unpause();
   }
 
-  function testFuzz_recoverSapientSignature_whenNotDisabled_returnsLeafForPayload(bytes32 digest, bytes memory data)
+  function test_pause_revertsForUnauthorizedCaller() external {
+    address outsider = makeAddr("outsider");
+
+    vm.prank(outsider);
+    vm.expectRevert(abi.encodeWithSelector(PayloadSwitchSapient.UnauthorizedPauser.selector, outsider));
+    sapient.pause();
+  }
+
+  function test_pause_revertsWhenAlreadyPaused() external {
+    vm.prank(owner);
+    sapient.pause();
+
+    vm.prank(owner);
+    vm.expectRevert(PayloadSwitchSapient.EnforcedPause.selector);
+    sapient.pause();
+  }
+
+  function test_unpause_revertsWhenNotPaused() external {
+    vm.prank(owner);
+    vm.expectRevert(PayloadSwitchSapient.ExpectedPause.selector);
+    sapient.unpause();
+  }
+
+  function test_setOperator_onlyOwner() external {
+    address outsider = makeAddr("outsider");
+
+    vm.prank(outsider);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, outsider));
+    sapient.setOperator(secondOperator, true);
+  }
+
+  function test_setOperator_updatesPermission() external {
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, true);
+    emit OperatorSet(secondOperator, true);
+    sapient.setOperator(secondOperator, true);
+
+    assertTrue(sapient.isOperator(secondOperator));
+
+    vm.prank(secondOperator);
+    sapient.pause();
+    assertTrue(sapient.paused());
+
+    vm.prank(owner);
+    sapient.unpause();
+
+    vm.prank(owner);
+    vm.expectEmit(true, false, false, true);
+    emit OperatorSet(secondOperator, false);
+    sapient.setOperator(secondOperator, false);
+
+    assertFalse(sapient.isOperator(secondOperator));
+  }
+
+  function test_setOperator_revertsOnZeroAddress() external {
+    vm.prank(owner);
+    vm.expectRevert(PayloadSwitchSapient.ZeroAddress.selector);
+    sapient.setOperator(address(0), true);
+  }
+
+  function test_constructor_revertsOnZeroOperator() external {
+    address[] memory initialOperators = new address[](1);
+    initialOperators[0] = address(0);
+
+    vm.expectRevert(PayloadSwitchSapient.ZeroAddress.selector);
+    new PayloadSwitchSapient(owner, initialOperators);
+  }
+
+  function testFuzz_recoverSapientSignature_whenNotPaused_returnsLeafForPayload(bytes32 digest, bytes memory data)
     external
   {
     Payload.Decoded memory payload = Payload.fromDigest(digest);
@@ -72,11 +171,11 @@ contract PayloadSwitchSapientTest is Test {
     assertEq(h, _expectedLeaf(payload));
   }
 
-  function testFuzz_recoverSapientSignature_whenDisabled_reverts(bytes32 digest, bytes memory data) external {
+  function testFuzz_recoverSapientSignature_whenPaused_reverts(bytes32 digest, bytes memory data) external {
     Payload.Decoded memory payload = Payload.fromDigest(digest);
     vm.prank(owner);
-    sapient.setDisabled(true);
-    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.pause();
+    vm.expectRevert(PayloadSwitchSapient.EnforcedPause.selector);
     sapient.recoverSapientSignature(payload, data);
   }
 }

--- a/test/PayloadSwitchSapient.t.sol
+++ b/test/PayloadSwitchSapient.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {PayloadSwitchSapient} from "src/modules/PayloadSwitchSapient.sol";
+
+contract PayloadSwitchSapientTest is Test {
+  address internal owner;
+  PayloadSwitchSapient internal sapient;
+
+  function setUp() external {
+    owner = makeAddr("owner");
+    vm.prank(owner);
+    sapient = new PayloadSwitchSapient(owner);
+  }
+
+  function test_constructor_setsOwner() external {
+    assertEq(sapient.owner(), owner);
+  }
+
+  function test_enabled_defaultsFalse() external {
+    assertFalse(sapient.enabled());
+  }
+
+  function test_recoverSapientSignatureCompact_revertsWhenDisabled() external {
+    bytes32 digest = bytes32(uint256(0xabc));
+    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.recoverSapientSignatureCompact(digest, hex"");
+  }
+
+  function test_setEnabled_owner_allowsRecoverToReturnDigest() external {
+    bytes32 digest = bytes32(uint256(0xdeadbeef));
+    vm.prank(owner);
+    sapient.setEnabled(true);
+    assertTrue(sapient.enabled());
+    bytes32 h = sapient.recoverSapientSignatureCompact(digest, hex"01");
+    assertEq(h, digest);
+  }
+
+  function test_setEnabled_owner_canDisableAgain() external {
+    bytes32 digest = bytes32(uint256(1));
+    vm.startPrank(owner);
+    sapient.setEnabled(true);
+    sapient.setEnabled(false);
+    vm.stopPrank();
+    assertFalse(sapient.enabled());
+    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.recoverSapientSignatureCompact(digest, "");
+  }
+
+  function test_setEnabled_nonOwner_reverts() external {
+    vm.prank(makeAddr("notOwner"));
+    vm.expectRevert(PayloadSwitchSapient.NotOwner.selector);
+    sapient.setEnabled(true);
+  }
+
+  function testFuzz_recoverSapientSignatureCompact_whenEnabled_returnsDigest(bytes32 digest, bytes memory data)
+    external
+  {
+    vm.prank(owner);
+    sapient.setEnabled(true);
+    bytes32 h = sapient.recoverSapientSignatureCompact(digest, data);
+    assertEq(h, digest);
+  }
+
+  function testFuzz_recoverSapientSignatureCompact_whenDisabled_reverts(bytes32 digest, bytes memory data) external {
+    vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
+    sapient.recoverSapientSignatureCompact(digest, data);
+  }
+}

--- a/test/PayloadSwitchSapient.t.sol
+++ b/test/PayloadSwitchSapient.t.sol
@@ -3,11 +3,17 @@ pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
 
+import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
 import {PayloadSwitchSapient} from "src/modules/PayloadSwitchSapient.sol";
 
 contract PayloadSwitchSapientTest is Test {
   address internal owner;
   PayloadSwitchSapient internal sapient;
+
+  function _expectedLeaf(Payload.Decoded memory payload) internal view returns (bytes32) {
+    bytes32 anyAddressOpHash = Payload.hashFor(payload, address(0));
+    return keccak256(abi.encodePacked("Sequence any address subdigest:\n", anyAddressOpHash));
+  }
 
   function setUp() external {
     owner = makeAddr("owner");
@@ -23,30 +29,30 @@ contract PayloadSwitchSapientTest is Test {
     assertFalse(sapient.enabled());
   }
 
-  function test_recoverSapientSignatureCompact_revertsWhenDisabled() external {
-    bytes32 digest = bytes32(uint256(0xabc));
+  function test_recoverSapientSignature_revertsWhenDisabled() external {
+    Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xabc)));
     vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
-    sapient.recoverSapientSignatureCompact(digest, hex"");
+    sapient.recoverSapientSignature(payload, hex"");
   }
 
-  function test_setEnabled_owner_allowsRecoverToReturnDigest() external {
-    bytes32 digest = bytes32(uint256(0xdeadbeef));
+  function test_setEnabled_owner_allowsRecoverToReturnLeafForPayload() external {
+    Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(0xdeadbeef)));
     vm.prank(owner);
     sapient.setEnabled(true);
     assertTrue(sapient.enabled());
-    bytes32 h = sapient.recoverSapientSignatureCompact(digest, hex"01");
-    assertEq(h, digest);
+    bytes32 h = sapient.recoverSapientSignature(payload, hex"01");
+    assertEq(h, _expectedLeaf(payload));
   }
 
   function test_setEnabled_owner_canDisableAgain() external {
-    bytes32 digest = bytes32(uint256(1));
+    Payload.Decoded memory payload = Payload.fromDigest(bytes32(uint256(1)));
     vm.startPrank(owner);
     sapient.setEnabled(true);
     sapient.setEnabled(false);
     vm.stopPrank();
     assertFalse(sapient.enabled());
     vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
-    sapient.recoverSapientSignatureCompact(digest, "");
+    sapient.recoverSapientSignature(payload, "");
   }
 
   function test_setEnabled_nonOwner_reverts() external {
@@ -55,17 +61,19 @@ contract PayloadSwitchSapientTest is Test {
     sapient.setEnabled(true);
   }
 
-  function testFuzz_recoverSapientSignatureCompact_whenEnabled_returnsDigest(bytes32 digest, bytes memory data)
+  function testFuzz_recoverSapientSignature_whenEnabled_returnsLeafForPayload(bytes32 digest, bytes memory data)
     external
   {
+    Payload.Decoded memory payload = Payload.fromDigest(digest);
     vm.prank(owner);
     sapient.setEnabled(true);
-    bytes32 h = sapient.recoverSapientSignatureCompact(digest, data);
-    assertEq(h, digest);
+    bytes32 h = sapient.recoverSapientSignature(payload, data);
+    assertEq(h, _expectedLeaf(payload));
   }
 
-  function testFuzz_recoverSapientSignatureCompact_whenDisabled_reverts(bytes32 digest, bytes memory data) external {
+  function testFuzz_recoverSapientSignature_whenDisabled_reverts(bytes32 digest, bytes memory data) external {
+    Payload.Decoded memory payload = Payload.fromDigest(digest);
     vm.expectRevert(PayloadSwitchSapient.Disabled.selector);
-    sapient.recoverSapientSignatureCompact(digest, data);
+    sapient.recoverSapientSignature(payload, data);
   }
 }


### PR DESCRIPTION
Adds the ability to lock "subdigest" authorisations behind an ownable kill switch. 

This replaces the current "subdigest" leaf. The leaf should instead be a sapient call to this contract and expect the image hash to be the same leaf digest as the wallet any address subdigest would have been. 

For Trails, this gives Polygon the ability to lock preapproved payload interactions on a given chain with a single flag. This does not impact recovery or prevent the owner from interacting with the intent directly. 