### PR TITLE
Add FixedImageSapient

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ onlyFallback: false
 
 [Sweep](src/modules/Sweep.sol) allows the entire balance (ERC20, address(this).balance) to be sent to another address.
 
+### FixedImageSapient
+
+[FixedImageSapient.sol](src/modules/FixedImageSapient.sol) implements [`ISapientCompact`](https://github.com/0xsequence/wallet-contracts-v3/blob/master/src/modules/interfaces/ISapient.sol): `recoverSapientSignatureCompact` always returns the owner-configured `imageHash` and ignores payload and signature bytes; only the owner may change it via `setImageHash`. THis is intended to be used in conjunction with other signers, as a failsafe kill switch. It is not included in [TrailsUtils.sol](src/TrailsUtils.sol), so deploy it as its own contract when a fixed sapient image is required.
+
 ## Glossary
 
 | Term           | Definition                                                     |
@@ -102,7 +106,7 @@ Any funds accumulated in the `TrailsUtils` context, via a `call` should be swept
 
 The Trails contracts are flexible in what they allow a configuration to represent. Misuse can cause an Intent to be exploitable.
 
-`RequireUtils`, `HydrateProxy` and `MalleableSapient` are tools to help create functionally complete and secure Intent configurations. The actual creation of the configuration must be done with care and is out of scope of this repository.
+`RequireUtils`, `HydrateProxy`, `MalleableSapient`, and `FixedImageSapient` are tools to help create functionally complete and secure Intent configurations. The actual creation of the configuration must be done with care and is out of scope of this repository.
 
 ### Token Handling
 

--- a/snapshots/FixedImageSapientTest.json
+++ b/snapshots/FixedImageSapientTest.json
@@ -1,0 +1,4 @@
+{
+  "recover_cold": "2368",
+  "recover_warm": "368"
+}

--- a/src/modules/FixedImageSapient.sol
+++ b/src/modules/FixedImageSapient.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {ISapientCompact} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
+
+/// @title FixedImageSapient
+/// @notice An `ISapientCompact` implementation that always returns an owner-configurable `imageHash` for any payload.
+contract FixedImageSapient is ISapientCompact {
+  /// @notice The caller is not the owner.
+  error NotOwner();
+
+  /// @notice The owner of the contract.
+  address public owner;
+
+  /// @notice The sapient image hash returned by `recoverSapientSignatureCompact`.
+  bytes32 internal imageHash;
+
+  constructor(address owner_) {
+    owner = owner_;
+  }
+
+  /// @notice Sets the image hash returned by recovery.
+  /// @param imageHash_ The new image hash.
+  function setImageHash(bytes32 imageHash_) external {
+    if (msg.sender != owner) {
+      revert NotOwner();
+    }
+    imageHash = imageHash_;
+  }
+
+  /// @inheritdoc ISapientCompact
+  function recoverSapientSignatureCompact(bytes32, bytes calldata) external view returns (bytes32) {
+    return imageHash;
+  }
+}

--- a/test/FixedImageSapient.t.sol
+++ b/test/FixedImageSapient.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {FixedImageSapient} from "src/modules/FixedImageSapient.sol";
+
+contract FixedImageSapientTest is Test {
+  address internal owner;
+  FixedImageSapient internal sapient;
+
+  function setUp() external {
+    owner = makeAddr("owner");
+    vm.prank(owner);
+    sapient = new FixedImageSapient(owner);
+  }
+
+  function test_constructor_setsOwner() external view {
+    assertEq(sapient.owner(), owner);
+  }
+
+  function test_recoverSapientSignatureCompact_returnsZeroByDefault() external view {
+    bytes32 h = sapient.recoverSapientSignatureCompact(bytes32(uint256(1)), hex"abcd");
+    assertEq(h, bytes32(0));
+  }
+
+  function test_setImageHash_owner_updatesImage() external {
+    bytes32 expected = bytes32(uint256(0xdead));
+    vm.prank(owner);
+    sapient.setImageHash(expected);
+    assertEq(sapient.recoverSapientSignatureCompact(bytes32(0), ""), expected);
+  }
+
+  function test_setImageHash_owner_canResetToZero() external {
+    vm.startPrank(owner);
+    sapient.setImageHash(bytes32(uint256(1)));
+    sapient.setImageHash(bytes32(0));
+    vm.stopPrank();
+    assertEq(sapient.recoverSapientSignatureCompact(bytes32(0), ""), bytes32(0));
+  }
+
+  function test_setImageHash_nonOwner_reverts() external {
+    address notOwner = makeAddr("notOwner");
+    vm.prank(notOwner);
+    vm.expectRevert(FixedImageSapient.NotOwner.selector);
+    sapient.setImageHash(bytes32(uint256(1)));
+  }
+
+  function testFuzz_recoverSapientSignatureCompact_ignoresOpHashAndData(bytes32 opHash, bytes memory data) external {
+    bytes32 image = bytes32(uint256(0xbeef));
+    vm.prank(owner);
+    sapient.setImageHash(image);
+    bytes32 h = sapient.recoverSapientSignatureCompact(opHash, data);
+    assertEq(h, image);
+  }
+
+  /// @dev Record warm and cold gas costs for `recoverSapientSignatureCompact` and check they are similar.
+  function test_gas_recoverSapientSignatureCompact_warmStorage() external {
+    sapient.recoverSapientSignatureCompact(bytes32(0), "");
+    uint256 gasCold = vm.snapshotGasLastCall("recover_cold");
+    sapient.recoverSapientSignatureCompact(bytes32(0), "");
+    uint256 gasWarm = vm.snapshotGasLastCall("recover_warm");
+  }
+}


### PR DESCRIPTION
This sapient can function effectively as a kill switch by using it as a 2/2 signer in conjunction with whatever feature we want to protect. e.g. OtherSapient (w:1) + FixedSapient (w:1) = threshold 2

Expect `FixedImageSapient` to return 0x00 under active operations. Any change in value will result in an invalid signature on the wallet. This can also work as a versioning flag or similar for more complex situations. 

In the case of Trails, this would not block recovery etc as the owner can still be on the intent wallet as a 1/1 signer. 
To disable, this must be updated on all affected chains. 
