### PR TITLE
Internal audit fixes (F02, F03 and F09)

### DIFF
--- a/itest/SequenceV3Integration.t.sol
+++ b/itest/SequenceV3Integration.t.sol
@@ -91,6 +91,14 @@ contract SequenceV3IntegrationTest is Test {
     }
   }
 
+  function _abiDynamicArgDataOffset(bytes memory callData, uint256 argIndex) private pure returns (uint256 offset) {
+    uint256 tailOffset;
+    assembly ("memory-safe") {
+      tailOffset := mload(add(add(callData, 36), shl(5, argIndex)))
+    }
+    return 4 + tailOffset + 32;
+  }
+
   function _randomBytes(uint256 len, bytes32 seed) private pure returns (bytes memory data) {
     data = new bytes(len);
 
@@ -337,6 +345,88 @@ contract SequenceV3IntegrationTest is Test {
 
     assertEq(receiver.lastSender(), wallet);
     assertEq(receiver.lastData(), dataB);
+  }
+
+  function test_integration_sapientStaticHydrateRange_isNotShiftedByPrependedTypeZeroCommand() external {
+    TrailsUtils trailsUtils = new TrailsUtils();
+
+    RecordingReceiver receiver = new RecordingReceiver();
+    address signedReceiver = makeAddr("signedReceiver");
+    address relayer = makeAddr("relayer");
+    address origin = makeAddr("origin");
+
+    LocalPayload.Call[] memory innerCalls = new LocalPayload.Call[](1);
+    innerCalls[0] = LocalPayload.Call({
+      to: address(receiver),
+      value: 0,
+      data: new bytes(20),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: LocalPayload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory innerPacked = innerCalls.packCalls();
+    bytes memory hydratePayload = bytes.concat(
+      abi.encodePacked(uint8(0)),
+      abi.encodePacked(uint8(0x13), signedReceiver, uint16(0)),
+      abi.encodePacked(uint8(0x00))
+    );
+    bytes memory shiftedHydratePayload = bytes.concat(
+      abi.encodePacked(uint8(0)),
+      abi.encodePacked(uint8(0x01), uint16(0xBEEF)),
+      abi.encodePacked(uint8(0x13), signedReceiver, uint16(0)),
+      abi.encodePacked(uint8(0x00))
+    );
+
+    bytes memory outerData = abi.encodeWithSelector(HydrateProxy.hydrateExecute.selector, innerPacked, hydratePayload);
+    uint16 signedRangeOffset = uint16(_abiDynamicArgDataOffset(outerData, 1) + 2);
+    bytes memory sapientSig = abi.encodePacked(uint8(0), signedRangeOffset, uint16(20));
+
+    LocalPayload.Call[] memory outerCalls = new LocalPayload.Call[](1);
+    outerCalls[0] = LocalPayload.Call({
+      to: address(trailsUtils),
+      value: 0,
+      data: outerData,
+      gasLimit: 0,
+      delegateCall: true,
+      onlyFallback: false,
+      behaviorOnError: LocalPayload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory shiftedOuterData =
+      abi.encodeWithSelector(HydrateProxy.hydrateExecute.selector, innerPacked, shiftedHydratePayload);
+    LocalPayload.Call[] memory shiftedOuterCalls = new LocalPayload.Call[](1);
+    shiftedOuterCalls[0] = LocalPayload.Call({
+      to: address(trailsUtils),
+      value: 0,
+      data: shiftedOuterData,
+      gasLimit: 0,
+      delegateCall: true,
+      onlyFallback: false,
+      behaviorOnError: LocalPayload.BEHAVIOR_REVERT_ON_ERROR
+    });
+
+    bytes memory outerPacked = outerCalls.packCalls();
+    bytes memory shiftedOuterPacked = shiftedOuterCalls.packCalls();
+
+    SeqPayload.Decoded memory payload = _asSeqPayload(outerCalls, 0, 0);
+    bytes32 sapientImageHash = ISapient(address(trailsUtils)).recoverSapientSignature(payload, sapientSig);
+    address wallet = _deployWalletWithSapient(address(trailsUtils), sapientImageHash);
+    bytes memory signature = _buildSapientSignature(address(trailsUtils), 1, 1, sapientSig);
+
+    vm.prank(relayer, origin);
+    vm.expectRevert();
+    SeqStage1Module(payable(wallet)).execute(shiftedOuterPacked, signature);
+
+    assertEq(SeqStage1Module(payable(wallet)).readNonce(0), 0);
+
+    vm.prank(relayer, origin);
+    SeqStage1Module(payable(wallet)).execute(outerPacked, signature);
+
+    assertEq(receiver.lastSender(), wallet);
+    assertEq(_readAddress(receiver.lastData(), 0), signedReceiver);
+    assertEq(SeqStage1Module(payable(wallet)).readNonce(0), 1);
   }
 
   function test_integration_walletDelegatecallsHydrateProxy_andHydrates() external {

--- a/src/autoRecovery/Allowlist.sol
+++ b/src/autoRecovery/Allowlist.sol
@@ -28,21 +28,21 @@ contract Allowlist is Ownable {
   /// @param initial The initial addresses to mark as allowed.
   constructor(address owner_, address[] memory initial) Ownable(owner_) {
     for (uint256 i; i < initial.length; i++) {
-      _add(initial[i], false);
+      _add(initial[i]);
     }
   }
 
   /// @notice Adds `addr` to the allowlist.
   /// @param addr The address to add.
   function add(address addr) external onlyOwner {
-    _add(addr, true);
+    _add(addr);
   }
 
   /// @notice Adds each address in `addrs` to the allowlist.
   /// @param addrs The addresses to add.
   function add(address[] calldata addrs) external onlyOwner {
     for (uint256 i; i < addrs.length; i++) {
-      _add(addrs[i], true);
+      _add(addrs[i]);
     }
   }
 
@@ -51,7 +51,7 @@ contract Allowlist is Ownable {
   /// @param index Optional index hint into `getAllowed()`. Pass `0` to use search mode.
   /// @dev Removal uses swap-and-pop, so `getAllowed()` ordering is not stable.
   function remove(address addr, uint256 index) external onlyOwner {
-    _remove(addr, index, true);
+    _remove(addr, index);
   }
 
   /// @notice Removes each address in `addrs` from the allowlist using search mode.
@@ -59,7 +59,7 @@ contract Allowlist is Ownable {
   /// @dev Removal uses swap-and-pop, so `getAllowed()` ordering is not stable.
   function remove(address[] calldata addrs) external onlyOwner {
     for (uint256 i; i < addrs.length; i++) {
-      _remove(addrs[i], 0, true);
+      _remove(addrs[i], 0);
     }
   }
 
@@ -74,17 +74,17 @@ contract Allowlist is Ownable {
     return _entries;
   }
 
-  function _add(address addr, bool emitEvent) private {
+  function _add(address addr) private {
     if (addr == address(0)) revert ZeroAddress();
     if (_allowed[addr]) revert AlreadyAllowed(addr);
 
     _allowed[addr] = true;
     _entries.push(addr);
 
-    if (emitEvent) emit AddressAdded(addr);
+    emit AddressAdded(addr);
   }
 
-  function _remove(address addr, uint256 index, bool emitEvent) private {
+  function _remove(address addr, uint256 index) private {
     if (!_allowed[addr]) revert NotAllowed(addr);
     _allowed[addr] = false;
 
@@ -103,6 +103,6 @@ contract Allowlist is Ownable {
       }
     }
 
-    if (emitEvent) emit AddressRemoved(addr);
+    emit AddressRemoved(addr);
   }
 }

--- a/src/modules/HydrateProxy.sol
+++ b/src/modules/HydrateProxy.sol
@@ -192,6 +192,10 @@ contract HydrateProxy is Sweepable, IDelegatedExtension {
       address valueAddress;
       (valueAddress, rindex) = _getAddressFromFlag(valueFlag, hydratePayload, rindex);
 
+      if (typeFlag == 0) {
+        revert UnknownHydrateTypeCommand(typeFlag);
+      }
+
       if (typeFlag <= HYDRATE_TYPE_DATA_ERC20_ALLOWANCE) {
         // Data hydration commands mutate `decoded.calls[tindex].data` in-place.
         (cindex, rindex) = hydratePayload.readUint16(rindex);

--- a/src/modules/Sweepable.sol
+++ b/src/modules/Sweepable.sol
@@ -31,8 +31,7 @@ contract Sweepable {
       // Sweep all token addresses specified
       for (uint256 i = 0; i < tokensToSweep.length; ++i) {
         uint256 balance = IERC20(tokensToSweep[i]).balanceOf(address(this));
-        if (balance > 0) {
-          IERC20(tokensToSweep[i]).safeTransfer(sweepToAddress, balance);
+        if (balance > 0 && IERC20(tokensToSweep[i]).trySafeTransfer(sweepToAddress, balance)) {
           emit Sweep(tokensToSweep[i], sweepToAddress, balance);
         }
       }

--- a/test/Allowlist.t.sol
+++ b/test/Allowlist.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {Allowlist} from "src/autoRecovery/Allowlist.sol";
@@ -37,6 +38,41 @@ contract AllowlistTest is Test {
     assertEq(all.length, 2);
     assertEq(all[0], first);
     assertEq(all[1], second);
+  }
+
+  function testFuzz_constructor_emitsAddressAddedForInitial(address owner_, address first, address second) external {
+    vm.assume(owner_ != address(0));
+    _assumeDistinctNonZero(first, second);
+
+    address[] memory initial = new address[](2);
+    initial[0] = first;
+    initial[1] = second;
+
+    vm.recordLogs();
+    new Allowlist(owner_, initial);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+
+    bytes32 addressAddedTopic = keccak256("AddressAdded(address)");
+    uint256 matches;
+
+    for (uint256 i; i < entries.length; i++) {
+      if (entries[i].topics.length > 0 && entries[i].topics[0] == addressAddedTopic) {
+        assertEq(entries[i].topics.length, 2);
+        address actual = address(uint160(uint256(entries[i].topics[1])));
+
+        if (matches == 0) {
+          assertEq(actual, first);
+        } else if (matches == 1) {
+          assertEq(actual, second);
+        } else {
+          fail();
+        }
+
+        matches++;
+      }
+    }
+
+    assertEq(matches, 2);
   }
 
   function testFuzz_constructor_revertsZeroAddress(address owner_, address first) external {

--- a/test/HydrateProxy.t.sol
+++ b/test/HydrateProxy.t.sol
@@ -644,13 +644,13 @@ contract HydrateProxyTest is Test {
   }
 
   function testFuzz_hydrateExecute_unknownHydrateFlag_reverts(uint8 flag) external {
-    // With nibble-based encoding, valid flags are 0x00-0x63
-    // Test invalid flags: either invalid value flag (bottom nibble > 0x03) or invalid type flag (top nibble > 0x06)
+    // With nibble-based encoding, the valid command flags are 0x10-0x63.
+    // 0x00 is the terminator; every other 0x0X value is invalid.
     uint8 valueFlag = flag & 0x0F;
     uint8 typeFlag = flag >> 4;
 
-    // Skip valid flags (0x00-0x63)
-    vm.assume(flag > 0x63 || (valueFlag > 0x03) || (typeFlag > 0x06 && valueFlag <= 0x03));
+    bool validFlag = flag == 0x00 || (typeFlag >= 0x01 && typeFlag <= 0x06 && valueFlag <= 0x03);
+    vm.assume(!validFlag);
 
     HydrateProxy proxy = new HydrateProxy();
     RecordingReceiver receiver = new RecordingReceiver();
@@ -676,6 +676,31 @@ contract HydrateProxyTest is Test {
       vm.expectRevert(abi.encodeWithSelector(HydrateProxy.UnknownHydrateTypeCommand.selector, uint256(typeFlag)));
     }
     proxy.hydrateExecute(calls.packCalls(), hydratePayload);
+  }
+
+  function test_hydrateExecute_typeZeroFlags_revert() external {
+    HydrateProxy proxy = new HydrateProxy();
+    RecordingReceiver receiver = new RecordingReceiver();
+
+    Payload.Call[] memory calls = new Payload.Call[](1);
+    calls[0] = Payload.Call({
+      to: address(receiver),
+      value: 0,
+      data: hex"01",
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_IGNORE_ERROR
+    });
+
+    vm.expectRevert(abi.encodeWithSelector(HydrateProxy.UnknownHydrateTypeCommand.selector, uint256(0)));
+    proxy.hydrateExecute(calls.packCalls(), abi.encodePacked(uint8(0), uint8(0x01)));
+
+    vm.expectRevert(abi.encodeWithSelector(HydrateProxy.UnknownHydrateTypeCommand.selector, uint256(0)));
+    proxy.hydrateExecute(calls.packCalls(), abi.encodePacked(uint8(0), uint8(0x02)));
+
+    vm.expectRevert(abi.encodeWithSelector(HydrateProxy.UnknownHydrateTypeCommand.selector, uint256(0)));
+    proxy.hydrateExecute(calls.packCalls(), abi.encodePacked(uint8(0), uint8(0x03), makeAddr("hydrated-owner")));
   }
 
   function testFuzz_hydrateExecute_delegateCallNotAllowed_reverts(bytes calldata data) external {

--- a/test/Sweepable.t.sol
+++ b/test/Sweepable.t.sol
@@ -6,7 +6,37 @@ import {Test} from "forge-std/Test.sol";
 import {Sweepable} from "src/modules/Sweepable.sol";
 import {MockERC20} from "test/helpers/Mocks.sol";
 
+contract ReturnBombERC20 {
+  mapping(address => uint256) public balanceOf;
+
+  uint256 internal immutable bombSize;
+
+  constructor(uint256 bombSize_) {
+    bombSize = bombSize_;
+  }
+
+  function mint(address to, uint256 amount) external {
+    balanceOf[to] += amount;
+  }
+
+  function transfer(address, uint256) external view returns (bool) {
+    uint256 size = bombSize;
+
+    assembly ("memory-safe") {
+      let ptr := mload(0x40)
+      mstore(0x40, add(ptr, size))
+      revert(ptr, size)
+    }
+  }
+}
+
 contract SweepableTest is Test {
+  uint256 internal constant GOOD_TOKEN_BALANCE = 2 ether;
+  uint256 internal constant BAD_TOKEN_BALANCE = 1 ether;
+  uint256 internal constant NATIVE_BALANCE = 3 ether;
+  uint256 internal constant RETURN_BOMB_SIZE = 1 << 20;
+  uint256 internal constant RETURN_BOMB_GAS_LIMIT = 3_500_000;
+
   Sweepable public sweepable;
 
   function setUp() public {
@@ -83,5 +113,30 @@ contract SweepableTest is Test {
     assertEq(sweepTarget.balance, 0);
     assertEq(address(sweepable).balance, 0);
   }
-}
 
+  function test_sweepReturnBombSkipsFailedTokenAndContinues() external {
+    MockERC20 goodToken = new MockERC20();
+    ReturnBombERC20 badToken = new ReturnBombERC20(RETURN_BOMB_SIZE);
+    address recipient = makeAddr("recipient");
+
+    goodToken.mint(address(sweepable), GOOD_TOKEN_BALANCE);
+    badToken.mint(address(sweepable), BAD_TOKEN_BALANCE);
+    vm.deal(address(sweepable), NATIVE_BALANCE);
+
+    address[] memory tokensToSweep = new address[](2);
+    tokensToSweep[0] = address(badToken);
+    tokensToSweep[1] = address(goodToken);
+
+    (bool success,) = address(sweepable).call{gas: RETURN_BOMB_GAS_LIMIT}(
+      abi.encodeCall(Sweepable.sweep, (recipient, tokensToSweep, true))
+    );
+
+    assertTrue(success);
+    assertEq(badToken.balanceOf(address(sweepable)), BAD_TOKEN_BALANCE);
+    assertEq(badToken.balanceOf(recipient), 0);
+    assertEq(goodToken.balanceOf(address(sweepable)), 0);
+    assertEq(goodToken.balanceOf(recipient), GOOD_TOKEN_BALANCE);
+    assertEq(address(sweepable).balance, 0);
+    assertEq(recipient.balance, NATIVE_BALANCE);
+  }
+}


### PR DESCRIPTION
Fixes for:

- F-02 — HydrateProxy: silent no-ops for flag bytes 0x01-0x03 enable stream manipulation in partial-commitment scenarios
- F-03 — Return-bomb via SafeERC20 in sweep() allows gas exhaustion
- F-09 — Allowlist: constructor does not emit AddressAdded events for initial signers