### PR TITLE
Add zero-balance validation to timed refund sapient

### DIFF
--- a/itest/SequenceV3Integration.t.sol
+++ b/itest/SequenceV3Integration.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import {TrailsUtils} from "src/TrailsUtils.sol";
 import {Allowlist} from "src/autoRecovery/Allowlist.sol";
+import {BalanceValidator} from "src/autoRecovery/BalanceValidator.sol";
 import {TimedRefundSapient} from "src/autoRecovery/TimedRefundSapient.sol";
 import {HydrateProxy} from "src/modules/HydrateProxy.sol";
 
@@ -186,6 +187,30 @@ contract SequenceV3IntegrationTest is Test {
     });
   }
 
+  function _requireZeroBalanceCall(address sapient) private pure returns (LocalPayload.Call memory) {
+    return LocalPayload.Call({
+      to: sapient,
+      value: 0,
+      data: abi.encodeWithSelector(BalanceValidator.requireZeroBalance.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: LocalPayload.BEHAVIOR_REVERT_ON_ERROR
+    });
+  }
+
+  function _requireZeroERC20BalanceCall(address sapient, address token) private pure returns (LocalPayload.Call memory) {
+    return LocalPayload.Call({
+      to: sapient,
+      value: 0,
+      data: abi.encodeWithSelector(BalanceValidator.requireZeroERC20Balance.selector, token),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: LocalPayload.BEHAVIOR_REVERT_ON_ERROR
+    });
+  }
+
   function _deployWalletWithSapient(address sapient, bytes32 sapientImageHash) private returns (address wallet) {
     SeqFactory factory = new SeqFactory();
     SeqStage1Module stage1 = new SeqStage1Module(address(factory), address(0));
@@ -215,6 +240,7 @@ contract SequenceV3IntegrationTest is Test {
 
     vm.warp(unlockTimestamp);
 
+    // First transfer (no zero validation)
     LocalPayload.Call[] memory firstCalls = new LocalPayload.Call[](1);
     firstCalls[0] = _erc20TransferCall(address(token), destination, firstAmount);
 
@@ -229,9 +255,12 @@ contract SequenceV3IntegrationTest is Test {
     assertEq(token.balanceOf(wallet), secondAmount);
     assertEq(SeqStage1Module(payable(wallet)).readNonce(sapient.TIMED_REFUND_NONCE_SPACE()), 1);
 
-    LocalPayload.Call[] memory secondCalls = new LocalPayload.Call[](2);
+    // Second transfer (with zero validation)
+    LocalPayload.Call[] memory secondCalls = new LocalPayload.Call[](4);
     secondCalls[0] = _erc20TransferCall(address(token), destination, secondAmount);
-    secondCalls[1] = _nativeTransferCall(destination, nativeAmount);
+    secondCalls[1] = _requireZeroERC20BalanceCall(address(sapient), address(token));
+    secondCalls[2] = _nativeTransferCall(destination, nativeAmount);
+    secondCalls[3] = _requireZeroBalanceCall(address(sapient));
 
     bytes memory secondPacked = secondCalls.packCallsWithSpaceNonce(sapient.TIMED_REFUND_NONCE_SPACE(), 1);
     SeqPayload.Decoded memory secondPayload = _asSeqPayload(secondCalls, sapient.TIMED_REFUND_NONCE_SPACE(), 1);

--- a/src/autoRecovery/BalanceValidator.sol
+++ b/src/autoRecovery/BalanceValidator.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.27;
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 /// @title BalanceValidator
-/// @notice Interface for a contract that validates the balance of an address.
+/// @notice Asserts the caller has zero native or ERC20 balance.
 contract BalanceValidator {
   /// @notice The `owner` has a non-zero balance.
   error NonZeroBalance(address owner);
   /// @notice The `owner` has a non-zero balance of `token`.
   error NonZeroERC20Balance(address token, address owner);
 
-  /// @notice Reverts if `token` has a non-zero balance.
+  /// @notice Reverts if the caller has a non-zero native balance.
   function requireZeroBalance() external view {
     address owner = msg.sender;
     if (owner.balance > 0) {
@@ -19,7 +19,7 @@ contract BalanceValidator {
     }
   }
 
-  /// @notice Reverts if `token` has a non-zero balance.
+  /// @notice Reverts if the caller has a non-zero balance of `token`.
   function requireZeroERC20Balance(address token) external view {
     address owner = msg.sender;
     if (IERC20(token).balanceOf(owner) > 0) {

--- a/src/autoRecovery/BalanceValidator.sol
+++ b/src/autoRecovery/BalanceValidator.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+/// @title BalanceValidator
+/// @notice Interface for a contract that validates the balance of an address.
+contract BalanceValidator {
+  /// @notice The `owner` has a non-zero balance.
+  error NonZeroBalance(address owner);
+  /// @notice The `owner` has a non-zero balance of `token`.
+  error NonZeroERC20Balance(address token, address owner);
+
+  /// @notice Reverts if `token` has a non-zero balance.
+  function requireZeroBalance() external view {
+    address owner = msg.sender;
+    if (owner.balance > 0) {
+      revert NonZeroBalance(owner);
+    }
+  }
+
+  /// @notice Reverts if `token` has a non-zero balance.
+  function requireZeroERC20Balance(address token) external view {
+    address owner = msg.sender;
+    if (IERC20(token).balanceOf(owner) > 0) {
+      revert NonZeroERC20Balance(token, owner);
+    }
+  }
+}

--- a/src/autoRecovery/TimedRefundSapient.sol
+++ b/src/autoRecovery/TimedRefundSapient.sol
@@ -6,16 +6,19 @@ import {ISapient} from "wallet-contracts-v3/modules/interfaces/ISapient.sol";
 import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
 import {IERC20Metadata} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {Allowlist} from "./Allowlist.sol";
+import {BalanceValidator} from "./BalanceValidator.sol";
 
 /// @title TimedRefundSapient
 /// @notice Sapient signer that authorizes time-locked refund batches to a fixed destination.
 /// @dev The returned image hash commits to `(destination, unlockTimestamp)` and only approves
 /// plain native transfers or ERC20 `transfer(address,uint256)` calls to that destination.
-contract TimedRefundSapient is ISapient {
+contract TimedRefundSapient is ISapient, BalanceValidator {
   /// @notice Dedicated nonce space for timed refund payloads.
   /// @dev uint160(uint256(keccak256("trails.timed-refund.nonce-space")) | (uint256(1) << 159))
   uint256 public constant TIMED_REFUND_NONCE_SPACE = uint256(uint160(0xeF25450978071B7bD3a1aFE58C4484c84B31FaF8));
 
+  bytes4 private constant BALANCE_VALIDATOR_NATIVE_SELECTOR = BalanceValidator.requireZeroBalance.selector;
+  bytes4 private constant BALANCE_VALIDATOR_ERC20_SELECTOR = BalanceValidator.requireZeroERC20Balance.selector;
   bytes4 private constant ERC20_TRANSFER_SELECTOR = IERC20.transfer.selector;
   uint256 private constant COMPACT_SIGNATURE_LENGTH = 64;
 
@@ -119,7 +122,18 @@ contract TimedRefundSapient is ISapient {
 
       bytes calldata data = call.data;
 
-      if (call.value == 0) {
+      if (call.to == address(this)) {
+        bytes4 selector = bytes4(data[:4]);
+        if (selector == BALANCE_VALIDATOR_NATIVE_SELECTOR) {
+          // Zero balance validation.
+          if (data.length != 4) revert UnauthorizedTransaction(i);
+        } else if (selector == BALANCE_VALIDATOR_ERC20_SELECTOR) {
+          // Zero ERC20 balance validation.
+          if (data.length != 36) revert UnauthorizedTransaction(i);
+        } else {
+          revert UnauthorizedTransaction(i);
+        }
+      } else if (call.value == 0) {
         if (!hasERC20Metadata(call.to)) revert UnauthorizedTransaction(i);
         // ERC20 transfer(address,uint256) to `destination`.
         if (data.length != 68) revert UnauthorizedTransaction(i);

--- a/src/autoRecovery/TimedRefundSapient.sol
+++ b/src/autoRecovery/TimedRefundSapient.sol
@@ -11,7 +11,8 @@ import {BalanceValidator} from "./BalanceValidator.sol";
 /// @title TimedRefundSapient
 /// @notice Sapient signer that authorizes time-locked refund batches to a fixed destination.
 /// @dev The returned image hash commits to `(destination, unlockTimestamp)` and only approves
-/// plain native transfers or ERC20 `transfer(address,uint256)` calls to that destination.
+/// plain native transfers or ERC20 `transfer(address,uint256)` calls to that destination, plus
+/// self-calls to `requireZeroBalance` and `requireZeroERC20Balance`.
 contract TimedRefundSapient is ISapient, BalanceValidator {
   /// @notice Dedicated nonce space for timed refund payloads.
   /// @dev uint160(uint256(keccak256("trails.timed-refund.nonce-space")) | (uint256(1) << 159))
@@ -110,7 +111,7 @@ contract TimedRefundSapient is ISapient, BalanceValidator {
     if (!allowlist.isAllowed(signer)) revert SignerNotAllowed(signer);
     if (block.timestamp < unlockTimestamp) revert UnlockTimestampNotReached(unlockTimestamp, block.timestamp);
 
-    // Restrict the approved surface to direct transfers into `destination`.
+    // Restrict the approved surface to transfers into `destination` and zero balance validation self-calls.
     for (uint256 i = 0; i < payload.calls.length; i++) {
       Payload.Call calldata call = payload.calls[i];
       if (call.behaviorOnError != Payload.BEHAVIOR_REVERT_ON_ERROR) {

--- a/src/autoRecovery/TimedRefundSapient.sol
+++ b/src/autoRecovery/TimedRefundSapient.sol
@@ -130,6 +130,8 @@ contract TimedRefundSapient is ISapient, BalanceValidator {
         } else if (selector == BALANCE_VALIDATOR_ERC20_SELECTOR) {
           // Zero ERC20 balance validation.
           if (data.length != 36) revert UnauthorizedTransaction(i);
+          address token = address(uint160(uint256(bytes32(data[4:36]))));
+          if (!hasERC20Metadata(token)) revert UnauthorizedTransaction(i);
         } else {
           revert UnauthorizedTransaction(i);
         }

--- a/test/BalanceValidator.t.sol
+++ b/test/BalanceValidator.t.sol
@@ -46,5 +46,4 @@ contract TimedRefundSapientTest is Test {
     vm.prank(wallet);
     validator.requireZeroERC20Balance(address(token));
   }
-
 }

--- a/test/BalanceValidator.t.sol
+++ b/test/BalanceValidator.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BalanceValidator} from "src/autoRecovery/BalanceValidator.sol";
+import {MockERC20} from "test/helpers/Mocks.sol";
+
+contract TimedRefundSapientTest is Test {
+  BalanceValidator internal validator;
+  MockERC20 internal token;
+  address internal wallet;
+
+  function setUp() external {
+    wallet = makeAddr("wallet");
+
+    validator = new BalanceValidator();
+
+    token = new MockERC20();
+  }
+
+  function test_requireZeroBalance_reverts_whenBalanceIsNotZero(uint256 balance) external {
+    vm.assume(balance > 0);
+    vm.deal(wallet, balance);
+
+    vm.prank(wallet);
+    vm.expectRevert(abi.encodeWithSelector(BalanceValidator.NonZeroBalance.selector, wallet));
+    validator.requireZeroBalance();
+  }
+
+  function test_requireZeroERC20Balance_reverts_whenBalanceIsNotZero(uint256 balance) external {
+    vm.assume(balance > 0);
+    token.mint(wallet, balance);
+
+    vm.prank(wallet);
+    vm.expectRevert(abi.encodeWithSelector(BalanceValidator.NonZeroERC20Balance.selector, address(token), wallet));
+    validator.requireZeroERC20Balance(address(token));
+  }
+
+  function test_requireZeroBalance_passes_whenBalanceIsZero() external {
+    vm.prank(wallet);
+    validator.requireZeroBalance();
+  }
+
+  function test_requireZeroERC20Balance_passes_whenBalanceIsZero() external {
+    vm.prank(wallet);
+    validator.requireZeroERC20Balance(address(token));
+  }
+
+}

--- a/test/TimedRefundSapient.t.sol
+++ b/test/TimedRefundSapient.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {IERC20Metadata} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import {Allowlist} from "src/autoRecovery/Allowlist.sol";
+import {BalanceValidator} from "src/autoRecovery/BalanceValidator.sol";
 import {TimedRefundSapient} from "src/autoRecovery/TimedRefundSapient.sol";
 import {MockERC20} from "test/helpers/Mocks.sol";
 import {Payload} from "wallet-contracts-v3/modules/Payload.sol";
@@ -319,9 +320,11 @@ contract TimedRefundSapientTest is Test {
     payload.noChainId = true;
     payload.space = sapient.TIMED_REFUND_NONCE_SPACE();
     payload.nonce = 99;
-    payload.calls = new Payload.Call[](2);
+    payload.calls = new Payload.Call[](4);
     payload.calls[0] = _erc20TransferCall(address(token), 123);
     payload.calls[1] = _nativeTransferCall(1 ether);
+    payload.calls[2] = _requireZeroBalanceCall();
+    payload.calls[3] = _requireZeroERC20BalanceCall(address(token));
   }
 
   function _erc20TransferCall(address token_, uint256 amount) private view returns (Payload.Call memory) {
@@ -341,6 +344,30 @@ contract TimedRefundSapientTest is Test {
       to: destination,
       value: amount,
       data: "",
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+  }
+
+  function _requireZeroBalanceCall() private view returns (Payload.Call memory call) {
+    return Payload.Call({
+      to: address(sapient),
+      value: 0,
+      data: abi.encodeWithSelector(BalanceValidator.requireZeroBalance.selector),
+      gasLimit: 0,
+      delegateCall: false,
+      onlyFallback: false,
+      behaviorOnError: Payload.BEHAVIOR_REVERT_ON_ERROR
+    });
+  }
+
+  function _requireZeroERC20BalanceCall(address token_) private view returns (Payload.Call memory call) {
+    return Payload.Call({
+      to: address(sapient),
+      value: 0,
+      data: abi.encodeWithSelector(BalanceValidator.requireZeroERC20Balance.selector, token_),
       gasLimit: 0,
       delegateCall: false,
       onlyFallback: false,


### PR DESCRIPTION
## Summary

Adds optional zero-balance checks to timed refund payloads so an integrator can require the wallet has no remaining native or ERC20 funds after refund transfers.

- Introduces `BalanceValidator` with `requireZeroBalance()` and `requireZeroERC20Balance(address)` — both inspect `msg.sender` and revert with `NonZeroBalance` / `NonZeroERC20Balance` when a balance remains.
- `TimedRefundSapient` inherits `BalanceValidator` and authorizes self-calls with those selectors (correct calldata length only). For `requireZeroERC20Balance`, the token argument must pass the same `hasERC20Metadata` check used for ERC20 transfer calls, so validation cannot target arbitrary or non-ERC20 addresses.
- Unit tests cover validator pass/revert paths and updated sapient payload fixtures; the Sequence v3 integration test exercises a second refund batch that includes ERC20 and native validation calls after the transfers.

## Test plan

- [ ] `forge test --match-contract BalanceValidatorTest`
- [ ] `forge test --match-contract TimedRefundSapientTest`
- [ ] `FOUNDRY_PROFILE=integration forge test -vvv`
